### PR TITLE
段ボールが200個より多い時にエラーが出る

### DIFF
--- a/src/main/java/com/tiscon/dao/EstimateDao.java
+++ b/src/main/java/com/tiscon/dao/EstimateDao.java
@@ -129,7 +129,7 @@ public class EstimateDao {
      * @return 料金[円]
      */
     public int getPricePerTruck(int boxNum) {
-        String sql = "SELECT PRICE FROM TRUCK_CAPACITY WHERE MAX_BOX >= :boxNum ORDER BY PRICE LIMIT 1";
+        String sql = "SELECT PRICE FROM TRUCK_CAPACITY WHERE MAX_BOX >= :boxNum ORDER BY MAX_BOX LIMIT 1";
 
         SqlParameterSource paramSource = new MapSqlParameterSource("boxNum", boxNum);
         return parameterJdbcTemplate.queryForObject(sql, paramSource, Integer.class);

--- a/src/main/java/com/tiscon/service/EstimateService.java
+++ b/src/main/java/com/tiscon/service/EstimateService.java
@@ -83,7 +83,19 @@ public class EstimateService {
                 + getBoxForPackage(dto.getWashingMachine(), PackageType.WASHING_MACHINE);
 
         // 箱に応じてトラックの種類が変わり、それに応じて料金が変わるためトラック料金を算出する。
-        int pricePerTruck = estimateDAO.getPricePerTruck(boxes);
+        int pricePerTruck = 0;
+        if (boxes >= 200) {
+            int priceFor200 = estimateDAO.getPricePerTruck(200);
+            for (int i = 0; i < (boxes / 200); i++) {
+                pricePerTruck += priceFor200;
+            }
+            int remainingBoxes = boxes % 200;
+            if (remainingBoxes != 0) {
+                pricePerTruck += estimateDAO.getPricePerTruck(remainingBoxes);
+            }
+        } else {
+            pricePerTruck = estimateDAO.getPricePerTruck(boxes);
+        }
 
         // オプションサービスの料金を算出する。
         int priceForOptionalService = 0;

--- a/src/test/java/com/tiscon/service/EstimateServiceTest.java
+++ b/src/test/java/com/tiscon/service/EstimateServiceTest.java
@@ -1,4 +1,207 @@
 package com.tiscon.service;
 
+import com.tiscon.dao.EstimateDao;
+import com.tiscon.dto.UserOrderDto;
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
 public class EstimateServiceTest {
+
+    @Autowired
+    private EstimateService sut;
+
+    @MockBean
+    private EstimateDao estimateDao;
+
+    @Before
+    public void prepareEstimateDaoForStaticData() {
+
+        Mockito.when(estimateDao.getBoxPerPackage(1)).thenReturn(1);
+        Mockito.when(estimateDao.getBoxPerPackage(2)).thenReturn(20);
+        Mockito.when(estimateDao.getBoxPerPackage(3)).thenReturn(15);
+        Mockito.when(estimateDao.getBoxPerPackage(4)).thenReturn(10);
+
+        Mockito.when(estimateDao.getPricePerOptionalService(1)).thenReturn(3000);
+    }
+
+    /**
+     * 全部の項目が指定された場合
+     */
+    @Test
+    public void testAllItemsIsSpecified() {
+
+        final UserOrderDto userOrderDto = new UserOrderDto();
+        userOrderDto.setOldPrefectureId("1");
+        userOrderDto.setNewPrefectureId("9");
+        userOrderDto.setBox("10");
+        userOrderDto.setBed("2");
+        userOrderDto.setBicycle("2");
+        userOrderDto.setWashingMachine("1");
+        userOrderDto.setWashingMachineInstallation(true);
+
+        Mockito.when(estimateDao.getDistance("1", "9")).thenReturn(100.123d);
+        Mockito.when(estimateDao.getPricePerTruck(90)).thenReturn(50000);
+
+        Assertions.assertThat(sut.getPrice(userOrderDto)).isEqualTo(63000);
+    }
+
+    /**
+     * 洗濯機の設置オプションを外した場合
+     */
+    @Test
+    public void testNoWashingMachineInstallation() {
+
+        final UserOrderDto userOrderDto = new UserOrderDto();
+        userOrderDto.setOldPrefectureId("1");
+        userOrderDto.setNewPrefectureId("9");
+        userOrderDto.setBox("10");
+        userOrderDto.setBed("2");
+        userOrderDto.setBicycle("2");
+        userOrderDto.setWashingMachine("1");
+        userOrderDto.setWashingMachineInstallation(false);
+
+        Mockito.when(estimateDao.getDistance("1", "9")).thenReturn(100.123d);
+        Mockito.when(estimateDao.getPricePerTruck(90)).thenReturn(50000);
+
+        Assertions.assertThat(sut.getPrice(userOrderDto)).isEqualTo(60000);
+    }
+
+    /**
+     * 箱が80個の場合
+     */
+    @Test
+    public void test80boxes() {
+
+        final UserOrderDto userOrderDto = new UserOrderDto();
+        userOrderDto.setOldPrefectureId("1");
+        userOrderDto.setNewPrefectureId("9");
+        userOrderDto.setBox("0");
+        userOrderDto.setBed("2");
+        userOrderDto.setBicycle("2");
+        userOrderDto.setWashingMachine("1");
+        userOrderDto.setWashingMachineInstallation(true);
+
+        Mockito.when(estimateDao.getDistance("1", "9")).thenReturn(100.123d);
+        Mockito.when(estimateDao.getPricePerTruck(80)).thenReturn(30000);
+
+        Assertions.assertThat(sut.getPrice(userOrderDto)).isEqualTo(43000);
+    }
+
+    /**
+     * 箱が81個の場合
+     */
+    @Test
+    public void test81boxes() {
+
+        final UserOrderDto userOrderDto = new UserOrderDto();
+        userOrderDto.setOldPrefectureId("1");
+        userOrderDto.setNewPrefectureId("9");
+        userOrderDto.setBox("1");
+        userOrderDto.setBed("2");
+        userOrderDto.setBicycle("2");
+        userOrderDto.setWashingMachine("1");
+        userOrderDto.setWashingMachineInstallation(true);
+
+        Mockito.when(estimateDao.getDistance("1", "9")).thenReturn(100.123d);
+        Mockito.when(estimateDao.getPricePerTruck(81)).thenReturn(50000);
+
+        Assertions.assertThat(sut.getPrice(userOrderDto)).isEqualTo(63000);
+    }
+
+    /**
+     * 箱が200個の場合
+     */
+    @Test
+    public void test200boxes() {
+
+        final UserOrderDto userOrderDto = new UserOrderDto();
+        userOrderDto.setOldPrefectureId("1");
+        userOrderDto.setNewPrefectureId("9");
+        userOrderDto.setBox("120");
+        userOrderDto.setBed("2");
+        userOrderDto.setBicycle("2");
+        userOrderDto.setWashingMachine("1");
+        userOrderDto.setWashingMachineInstallation(true);
+
+        Mockito.when(estimateDao.getDistance("1", "9")).thenReturn(100.123d);
+        Mockito.when(estimateDao.getPricePerTruck(200)).thenReturn(50000);
+
+        Assertions.assertThat(sut.getPrice(userOrderDto)).isEqualTo(63000);
+    }
+
+    /**
+     * 箱が201個の場合
+     */
+    @Test
+    public void test201boxes() {
+
+        final UserOrderDto userOrderDto = new UserOrderDto();
+        userOrderDto.setOldPrefectureId("1");
+        userOrderDto.setNewPrefectureId("9");
+        userOrderDto.setBox("121");
+        userOrderDto.setBed("2");
+        userOrderDto.setBicycle("2");
+        userOrderDto.setWashingMachine("1");
+        userOrderDto.setWashingMachineInstallation(true);
+
+        Mockito.when(estimateDao.getDistance("1", "9")).thenReturn(100.123d);
+        Mockito.when(estimateDao.getPricePerTruck(200)).thenReturn(50000);
+        Mockito.when(estimateDao.getPricePerTruck(1)).thenReturn(30000);
+
+        Assertions.assertThat(sut.getPrice(userOrderDto)).isEqualTo(93000);
+    }
+
+    /**
+     * 箱が400個の場合
+     */
+    @Test
+    public void test400boxes() {
+
+        final UserOrderDto userOrderDto = new UserOrderDto();
+        userOrderDto.setOldPrefectureId("1");
+        userOrderDto.setNewPrefectureId("9");
+        userOrderDto.setBox("320");
+        userOrderDto.setBed("2");
+        userOrderDto.setBicycle("2");
+        userOrderDto.setWashingMachine("1");
+        userOrderDto.setWashingMachineInstallation(true);
+
+        Mockito.when(estimateDao.getDistance("1", "9")).thenReturn(100.123d);
+        Mockito.when(estimateDao.getPricePerTruck(200)).thenReturn(50000);
+        Mockito.when(estimateDao.getPricePerTruck(200)).thenReturn(50000);
+
+        Assertions.assertThat(sut.getPrice(userOrderDto)).isEqualTo(113000);
+    }
+
+    /**
+     * 箱が401個の場合
+     */
+    @Test
+    public void test401boxes() {
+
+        final UserOrderDto userOrderDto = new UserOrderDto();
+        userOrderDto.setOldPrefectureId("1");
+        userOrderDto.setNewPrefectureId("9");
+        userOrderDto.setBox("321");
+        userOrderDto.setBed("2");
+        userOrderDto.setBicycle("2");
+        userOrderDto.setWashingMachine("1");
+        userOrderDto.setWashingMachineInstallation(true);
+
+        Mockito.when(estimateDao.getDistance("1", "9")).thenReturn(100.123d);
+        Mockito.when(estimateDao.getPricePerTruck(200)).thenReturn(50000);
+        Mockito.when(estimateDao.getPricePerTruck(200)).thenReturn(50000);
+        Mockito.when(estimateDao.getPricePerTruck(1)).thenReturn(30000);
+
+        Assertions.assertThat(sut.getPrice(userOrderDto)).isEqualTo(143000);
+    }
 }

--- a/src/test/java/com/tiscon/service/EstimateServiceTest.java
+++ b/src/test/java/com/tiscon/service/EstimateServiceTest.java
@@ -1,0 +1,4 @@
+package com.tiscon.service;
+
+public class EstimateServiceTest {
+}


### PR DESCRIPTION
#10

- [x] ユニットテストを追加する
- [x] すべての箱を運べるようにトラックを選択するように箱の計算部分を修正する
- [x] アプリを動作確認してSQL含めて動作確認する

動作確認は200個、201個、400個、401個で確認しました。